### PR TITLE
style: make portfolio professional and minimalist

### DIFF
--- a/_layouts/portfolio.html
+++ b/_layouts/portfolio.html
@@ -6,7 +6,7 @@
   <title>{% if page.title %}{{ page.title }} · {% endif %}{{ site.title }}</title>
   <meta name="description" content="{{ page.description | default: site.description | escape }}">
   <meta name="author" content="{{ site.author.name }}">
-  <meta name="theme-color" content="#0b1220">
+  <meta name="theme-color" content="#ffffff">
   <meta property="og:type" content="website">
   <meta property="og:title" content="{{ page.title | default: site.title | escape }}">
   <meta property="og:description" content="{{ page.description | default: site.description | escape }}">

--- a/css/portfolio.scss
+++ b/css/portfolio.scss
@@ -2,20 +2,13 @@
 ---
 
 :root {
-  --bg: #0b1220;
-  --bg-soft: #111a2b;
-  --surface: #ffffff;
-  --surface-soft: #f5f7fb;
-  --text: #152033;
-  --text-soft: #5f6b7a;
-  --text-on-dark: #eef3fb;
-  --muted-on-dark: #a9b7ca;
-  --line: #dfe5ee;
-  --accent: #e58b3a;
-  --accent-strong: #c96e20;
-  --max: 1160px;
-  --radius: 22px;
-  --shadow: 0 22px 60px rgba(14, 23, 38, .09);
+  --bg: #ffffff;
+  --bg-muted: #f6f6f3;
+  --text: #171717;
+  --muted: #6b6b66;
+  --line: #e4e4df;
+  --accent: #2457d6;
+  --max: 1120px;
 }
 
 * { box-sizing: border-box; }
@@ -24,13 +17,13 @@ body {
   margin: 0;
   font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   color: var(--text);
-  background: var(--surface);
+  background: var(--bg);
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
 }
 
 a { color: inherit; }
-img { max-width: 100%; display: block; }
+img { display: block; max-width: 100%; }
 
 .skip-link {
   position: fixed;
@@ -38,410 +31,376 @@ img { max-width: 100%; display: block; }
   top: -60px;
   z-index: 1000;
   padding: 10px 14px;
-  border-radius: 10px;
   background: #fff;
-  color: #000;
+  border: 1px solid var(--line);
 }
 .skip-link:focus { top: 16px; }
 
 .container {
-  width: min(calc(100% - 40px), var(--max));
+  width: min(calc(100% - 48px), var(--max));
   margin: 0 auto;
 }
 
 .site-nav {
-  position: absolute;
-  inset: 0 0 auto;
-  z-index: 10;
-  padding: 26px 0;
-  color: var(--text-on-dark);
+  border-bottom: 1px solid var(--line);
+  background: #fff;
 }
-
 .nav-inner {
+  min-height: 72px;
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  justify-content: space-between;
   gap: 28px;
 }
-
 .brand {
-  display: inline-flex;
-  align-items: center;
-  gap: 12px;
   text-decoration: none;
-  font-weight: 750;
-  letter-spacing: -.02em;
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: -.01em;
 }
-
-.brand-mark {
-  width: 38px;
-  height: 38px;
-  display: grid;
-  place-items: center;
-  border: 1px solid rgba(255,255,255,.2);
-  border-radius: 12px;
-  background: rgba(255,255,255,.07);
-  font-size: 14px;
-}
-
 .nav-links {
   display: flex;
-  gap: 24px;
   align-items: center;
-  font-size: 14px;
+  gap: 26px;
+  font-size: 13px;
 }
-
 .nav-links a {
+  color: var(--muted);
   text-decoration: none;
-  color: var(--muted-on-dark);
 }
-.nav-links a:hover, .nav-links a:focus { color: #fff; }
-
-.nav-cta {
-  padding: 10px 15px;
-  border: 1px solid rgba(255,255,255,.22);
-  border-radius: 999px;
-  color: #fff !important;
-  background: rgba(255,255,255,.06);
-}
+.nav-links a:hover,
+.nav-links a:focus { color: var(--text); }
 
 .hero {
-  position: relative;
-  overflow: hidden;
-  min-height: 760px;
-  display: flex;
-  align-items: center;
-  background:
-    radial-gradient(circle at 82% 22%, rgba(229,139,58,.16), transparent 34%),
-    radial-gradient(circle at 20% 70%, rgba(86,116,163,.16), transparent 30%),
-    var(--bg);
-  color: var(--text-on-dark);
+  padding: 108px 0 96px;
+  border-bottom: 1px solid var(--line);
 }
-
-.hero::before {
-  content: "";
-  position: absolute;
-  width: 520px;
-  height: 520px;
-  right: -180px;
-  bottom: -220px;
-  border: 1px solid rgba(255,255,255,.06);
-  border-radius: 50%;
-  box-shadow: 0 0 0 80px rgba(255,255,255,.015), 0 0 0 160px rgba(255,255,255,.01);
-}
-
 .hero-grid {
-  position: relative;
-  z-index: 1;
   display: grid;
-  grid-template-columns: minmax(0, 1.35fr) minmax(300px, .65fr);
-  gap: 72px;
-  align-items: center;
-  padding: 148px 0 96px;
+  grid-template-columns: minmax(0, 1.45fr) minmax(280px, .55fr);
+  gap: 92px;
+  align-items: start;
 }
-
-.eyebrow {
-  display: inline-flex;
-  align-items: center;
-  gap: 9px;
-  margin: 0 0 22px;
-  color: #f5b578;
-  font-size: 13px;
-  font-weight: 800;
-  letter-spacing: .12em;
+.hero-main { padding-top: 12px; }
+.eyebrow,
+.section-kicker {
+  margin: 0 0 20px;
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: .1em;
   text-transform: uppercase;
 }
-
-.eyebrow::before {
-  content: "";
-  width: 28px;
-  height: 1px;
-  background: currentColor;
-}
-
 .hero h1 {
+  max-width: 800px;
   margin: 0;
-  max-width: 760px;
-  font-size: clamp(48px, 7vw, 82px);
-  line-height: .99;
-  letter-spacing: -.055em;
+  font-size: clamp(48px, 6.3vw, 76px);
+  line-height: 1.01;
+  letter-spacing: -.052em;
+  font-weight: 650;
 }
-
-.hero h1 span { color: #aebbd0; }
-
 .hero-copy {
   max-width: 720px;
-  margin: 28px 0 0;
-  color: var(--muted-on-dark);
-  font-size: clamp(18px, 2vw, 21px);
+  margin: 30px 0 0;
+  color: var(--muted);
+  font-size: clamp(18px, 1.8vw, 21px);
 }
-
-.hero-actions {
+.hero-copy strong { color: var(--text); font-weight: 600; }
+.hero-actions,
+.contact-links {
+  margin-top: 32px;
   display: flex;
+  align-items: center;
   flex-wrap: wrap;
-  gap: 12px;
-  margin-top: 34px;
+  gap: 20px;
 }
 
 .button {
+  min-height: 44px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 48px;
-  padding: 0 18px;
-  border-radius: 12px;
+  padding: 0 17px;
+  border-radius: 7px;
   text-decoration: none;
-  font-weight: 750;
-  font-size: 14px;
-  transition: transform .18s ease, background .18s ease, border-color .18s ease;
+  font-size: 13px;
+  font-weight: 650;
 }
-.button:hover { transform: translateY(-2px); }
-.button-primary { background: var(--accent); color: #1a120b; }
-.button-primary:hover { background: #f0a35c; }
-.button-secondary { border: 1px solid rgba(255,255,255,.18); color: #fff; background: rgba(255,255,255,.04); }
-
-.hero-card {
-  padding: 28px;
-  border: 1px solid rgba(255,255,255,.12);
-  border-radius: 28px;
-  background: linear-gradient(180deg, rgba(255,255,255,.08), rgba(255,255,255,.035));
-  box-shadow: 0 30px 80px rgba(0,0,0,.22);
-  backdrop-filter: blur(12px);
+.button-primary {
+  color: #fff;
+  background: var(--text);
 }
-
-.profile-row {
-  display: flex;
-  gap: 16px;
-  align-items: center;
-  margin-bottom: 26px;
+.button-primary:hover { background: #2d2d2d; }
+.text-link {
+  color: var(--text);
+  text-decoration: none;
+  font-size: 13px;
+  font-weight: 650;
+  border-bottom: 1px solid #bdbdb7;
 }
+.text-link:hover { border-bottom-color: var(--text); }
 
+.profile-summary { padding-top: 2px; }
 .profile-photo {
-  width: 70px;
-  height: 70px;
+  width: 84px;
+  height: 84px;
   object-fit: cover;
-  border-radius: 18px;
-  filter: grayscale(20%);
+  border-radius: 50%;
+  filter: grayscale(100%);
 }
-.profile-name { font-weight: 800; font-size: 18px; }
-.profile-meta { color: var(--muted-on-dark); font-size: 14px; }
-
-.quick-facts {
+.profile-details {
+  margin-top: 20px;
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 12px;
+  gap: 2px;
 }
-
-.fact {
-  min-height: 112px;
-  padding: 17px;
-  border-radius: 16px;
-  background: rgba(4,10,20,.33);
+.profile-details strong { font-size: 16px; }
+.profile-details span { color: var(--muted); font-size: 13px; }
+.profile-facts {
+  margin: 28px 0 0;
+  border-top: 1px solid var(--line);
 }
-.fact strong { display: block; font-size: 26px; color: #fff; letter-spacing: -.04em; }
-.fact span { display: block; margin-top: 4px; color: var(--muted-on-dark); font-size: 13px; line-height: 1.4; }
+.profile-facts div {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--line);
+  font-size: 13px;
+}
+.profile-facts dt { color: var(--muted); }
+.profile-facts dd { margin: 0; text-align: right; font-weight: 600; }
+.profile-links {
+  margin-top: 18px;
+  display: flex;
+  gap: 18px;
+  font-size: 13px;
+}
+.profile-links a { text-decoration: none; color: var(--muted); }
+.profile-links a:hover { color: var(--text); }
 
-section { padding: 100px 0; }
-.section-soft { background: var(--surface-soft); }
-.section-dark { background: var(--bg); color: var(--text-on-dark); }
-
+section { padding: 96px 0; }
+.section-muted { background: var(--bg-muted); }
 .section-heading {
   display: grid;
-  grid-template-columns: .55fr 1.45fr;
-  gap: 60px;
+  grid-template-columns: 180px minmax(0, 1fr);
+  gap: 48px;
   align-items: start;
   margin-bottom: 54px;
 }
-.section-kicker {
-  margin: 0;
-  color: var(--accent-strong);
-  font-size: 13px;
-  font-weight: 800;
-  letter-spacing: .11em;
-  text-transform: uppercase;
-}
-.section-heading h2 {
+.section-heading h2,
+.approach-grid h2,
+.contact-section h2 {
   margin: 0;
   max-width: 760px;
-  font-size: clamp(34px, 5vw, 54px);
-  line-height: 1.05;
-  letter-spacing: -.045em;
+  font-size: clamp(34px, 4.2vw, 52px);
+  line-height: 1.08;
+  letter-spacing: -.042em;
+  font-weight: 600;
 }
-.section-heading p {
-  margin: 18px 0 0;
-  max-width: 720px;
-  color: var(--text-soft);
-  font-size: 18px;
-}
-.section-dark .section-heading p { color: var(--muted-on-dark); }
 
 .capabilities {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 18px;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
 }
-.capability {
-  padding: 28px;
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
-  background: #fff;
+.capability { padding: 30px 30px 34px 0; }
+.capability + .capability {
+  border-left: 1px solid var(--line);
+  padding-left: 30px;
 }
-.capability-index {
-  display: inline-grid;
-  place-items: center;
-  width: 34px;
-  height: 34px;
-  border-radius: 10px;
-  background: #f6e8dc;
-  color: #a45218;
-  font-size: 12px;
-  font-weight: 850;
+.capability h3 {
+  margin: 0 0 12px;
+  font-size: 18px;
+  letter-spacing: -.02em;
 }
-.capability h3 { margin: 22px 0 10px; font-size: 22px; letter-spacing: -.025em; }
-.capability p { margin: 0; color: var(--text-soft); }
-
+.capability p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+}
 .stack-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
-  margin-top: 34px;
+  gap: 8px 16px;
+  margin-top: 28px;
 }
-.pill {
-  padding: 9px 12px;
-  border: 1px solid var(--line);
-  border-radius: 999px;
-  background: #fff;
-  color: #344054;
-  font-size: 13px;
-  font-weight: 700;
+.stack-row span {
+  color: var(--muted);
+  font-size: 12px;
 }
+.stack-row span::after {
+  content: "·";
+  margin-left: 16px;
+  color: #b8b8b2;
+}
+.stack-row span:last-child::after { display: none; }
 
-.timeline { display: grid; gap: 16px; }
+.timeline { border-top: 1px solid var(--line); }
 .role {
   display: grid;
-  grid-template-columns: 210px 1fr;
-  gap: 36px;
-  padding: 32px 0;
-  border-top: 1px solid var(--line);
+  grid-template-columns: 230px minmax(0, 1fr);
+  gap: 54px;
+  padding: 34px 0;
+  border-bottom: 1px solid var(--line);
 }
-.role:last-child { border-bottom: 1px solid var(--line); }
-.role-company { font-size: 15px; font-weight: 850; }
-.role-period { margin-top: 5px; color: var(--text-soft); font-size: 13px; }
-.role h3 { margin: 0; font-size: 25px; letter-spacing: -.03em; }
-.role p { margin: 10px 0 0; color: var(--text-soft); max-width: 800px; }
-.role-tags { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 16px; }
-.role-tags span { font-size: 12px; font-weight: 750; color: #526071; }
-
-.brand-cloud {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  margin-top: 34px;
+.role-meta { display: grid; align-content: start; gap: 4px; }
+.role-meta strong { font-size: 14px; }
+.role-meta span { color: var(--muted); font-size: 12px; }
+.role-content h3 {
+  margin: 0 0 9px;
+  font-size: 21px;
+  letter-spacing: -.025em;
+  font-weight: 600;
 }
-.brand-chip {
-  padding: 9px 13px;
-  border-radius: 10px;
-  background: #e9edf4;
-  color: #394657;
+.role-content p {
+  max-width: 760px;
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+}
+.role-stack {
+  display: block;
+  margin-top: 13px;
+  color: #888883;
+  font-size: 12px;
+}
+.other-environments {
+  max-width: 760px;
+  margin: 28px 0 0 284px;
+  color: var(--muted);
   font-size: 13px;
-  font-weight: 750;
 }
 
 .projects {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 18px;
+  gap: 16px;
 }
 .project-card {
+  min-height: 300px;
   display: flex;
   flex-direction: column;
-  min-height: 350px;
-  padding: 28px;
-  border: 1px solid rgba(255,255,255,.11);
-  border-radius: var(--radius);
-  background: var(--bg-soft);
+  padding: 24px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: #fff;
   text-decoration: none;
-  transition: transform .18s ease, border-color .18s ease;
+  transition: border-color .15s ease, transform .15s ease;
 }
-.project-card:hover { transform: translateY(-4px); border-color: rgba(229,139,58,.7); }
-.project-number { color: #f0a35c; font-size: 12px; font-weight: 850; }
-.project-card h3 { margin: 70px 0 12px; font-size: 25px; letter-spacing: -.035em; }
-.project-card p { margin: 0; color: var(--muted-on-dark); }
-.project-tech { margin-top: auto; padding-top: 28px; color: #d1d9e6; font-size: 12px; font-weight: 750; }
+.project-card:hover {
+  border-color: #b7b7b0;
+  transform: translateY(-2px);
+}
+.project-label {
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .07em;
+  text-transform: uppercase;
+}
+.project-card h3 {
+  margin: 48px 0 10px;
+  font-size: 22px;
+  letter-spacing: -.03em;
+  font-weight: 600;
+}
+.project-card p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+}
+.project-tech {
+  margin-top: auto;
+  padding-top: 30px;
+  color: #8b8b85;
+  font-size: 11px;
+}
+.work-link { display: inline-block; margin-top: 26px; }
 
 .approach-grid {
   display: grid;
-  grid-template-columns: 1.1fr .9fr;
-  gap: 54px;
+  grid-template-columns: minmax(0, 1fr) minmax(340px, .8fr);
+  gap: 90px;
   align-items: start;
 }
-.approach-copy h2 { margin: 0; font-size: clamp(34px, 5vw, 52px); line-height: 1.05; letter-spacing: -.045em; }
-.approach-copy p { color: var(--text-soft); font-size: 18px; }
-.principles { display: grid; gap: 12px; }
-.principle {
-  padding: 20px 22px;
-  border: 1px solid var(--line);
-  border-radius: 16px;
-  background: #fff;
+.principles { border-top: 1px solid var(--line); }
+.principles p {
+  margin: 0;
+  padding: 18px 0;
+  border-bottom: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 14px;
 }
-.principle strong { display: block; margin-bottom: 4px; }
-.principle span { color: var(--text-soft); font-size: 14px; }
+.principles strong { color: var(--text); font-weight: 600; }
 
-.contact-card {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  gap: 40px;
-  align-items: center;
-  padding: 46px;
-  border-radius: 28px;
-  background: linear-gradient(135deg, #101a2b, #18263d);
-  color: var(--text-on-dark);
-  box-shadow: var(--shadow);
+.contact-section { max-width: 820px; margin-left: 0; }
+.contact-section > p:not(.section-kicker) {
+  margin: 18px 0 0;
+  color: var(--muted);
+  font-size: 16px;
 }
-.contact-card h2 { margin: 0; font-size: clamp(32px, 5vw, 48px); line-height: 1.08; letter-spacing: -.04em; }
-.contact-card p { margin: 12px 0 0; color: var(--muted-on-dark); max-width: 700px; }
-.contact-links { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 10px; }
 
 .site-footer {
-  padding: 30px 0 44px;
-  color: #7a8798;
-  font-size: 13px;
+  padding: 28px 0 36px;
+  border-top: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 12px;
 }
-.footer-inner { display: flex; justify-content: space-between; gap: 20px; }
-.footer-inner a { color: inherit; }
+.footer-inner {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+}
 
-:focus-visible { outline: 3px solid rgba(229,139,58,.55); outline-offset: 4px; }
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+}
 
 @media (max-width: 900px) {
-  .hero { min-height: auto; }
-  .hero-grid, .section-heading, .approach-grid { grid-template-columns: 1fr; gap: 34px; }
-  .hero-grid { padding-top: 138px; }
-  .hero-card { max-width: 620px; }
-  .capabilities, .projects { grid-template-columns: 1fr; }
-  .project-card { min-height: 290px; }
-  .project-card h3 { margin-top: 44px; }
-  .role { grid-template-columns: 1fr; gap: 12px; }
-  .contact-card { grid-template-columns: 1fr; }
-  .contact-links { justify-content: flex-start; }
+  .hero { padding: 82px 0 76px; }
+  .hero-grid,
+  .section-heading,
+  .approach-grid {
+    grid-template-columns: 1fr;
+    gap: 36px;
+  }
+  .profile-summary { max-width: 440px; }
+  .capabilities,
+  .projects { grid-template-columns: 1fr; }
+  .capability,
+  .capability + .capability {
+    padding: 24px 0;
+    border-left: 0;
+    border-top: 1px solid var(--line);
+  }
+  .capability:first-child { border-top: 0; }
+  .role { grid-template-columns: 1fr; gap: 14px; }
+  .other-environments { margin-left: 0; }
+  .project-card { min-height: 240px; }
+  .project-card h3 { margin-top: 34px; }
 }
 
 @media (max-width: 680px) {
-  .container { width: min(calc(100% - 28px), var(--max)); }
-  .site-nav { padding-top: 18px; }
-  .nav-links a:not(.nav-cta) { display: none; }
-  .hero-grid { padding: 122px 0 72px; }
-  .hero h1 { font-size: 49px; }
+  .container { width: min(calc(100% - 30px), var(--max)); }
+  .nav-inner { min-height: 64px; }
+  .nav-links { gap: 14px; }
+  .nav-links a:nth-child(2),
+  .nav-links a:nth-child(3) { display: none; }
+  .hero { padding: 66px 0 62px; }
+  .hero h1 { font-size: 44px; }
   .hero-copy { font-size: 17px; }
-  .quick-facts { grid-template-columns: 1fr 1fr; }
-  .fact { min-height: 102px; padding: 15px; }
-  section { padding: 74px 0; }
-  .section-heading { margin-bottom: 36px; }
-  .capability, .project-card { padding: 22px; }
-  .contact-card { padding: 28px; }
-  .footer-inner { flex-direction: column; }
+  section { padding: 72px 0; }
+  .section-heading { margin-bottom: 38px; }
+  .section-heading h2,
+  .approach-grid h2,
+  .contact-section h2 { font-size: 34px; }
+  .stack-row span::after { margin-left: 10px; }
+  .footer-inner { flex-direction: column; gap: 4px; }
 }
 
 @media (prefers-reduced-motion: reduce) {
   html { scroll-behavior: auto; }
-  *, *::before, *::after { transition: none !important; }
+  .project-card { transition: none; }
 }

--- a/index.html
+++ b/index.html
@@ -6,48 +6,46 @@ description: Senior Full-Stack Engineer and Tech Lead with 11+ years of experien
 
 <nav class="site-nav" aria-label="Primary navigation">
   <div class="container nav-inner">
-    <a class="brand" href="{{ site.baseurl }}/" aria-label="Eissa Soubhi home">
-      <span class="brand-mark">ES</span>
-      <span>Eissa Soubhi</span>
-    </a>
+    <a class="brand" href="{{ site.baseurl }}/">Eissa Soubhi</a>
     <div class="nav-links">
       <a href="#expertise">Expertise</a>
       <a href="#experience">Experience</a>
-      <a href="#work">Open source</a>
-      <a class="nav-cta" href="#contact">Contact</a>
+      <a href="#work">Work</a>
+      <a href="#contact">Contact</a>
     </div>
   </div>
 </nav>
 
 <header class="hero">
   <div class="container hero-grid">
-    <div>
+    <div class="hero-main">
       <p class="eyebrow">Senior Full-Stack Engineer · Tech Lead</p>
-      <h1>I build web products that <span>survive production.</span></h1>
+      <h1>Building reliable web products, from architecture to delivery.</h1>
       <p class="hero-copy">
-        11+ years designing, modernizing and shipping production platforms across backend, frontend and architecture.
-        Strongest in <strong>PHP / Symfony</strong>, with modern <strong>TypeScript, React / Next.js and Vue / Nuxt</strong> frontends.
+        11+ years of experience across backend, frontend and technical leadership.
+        Strong focus on <strong>PHP / Symfony</strong>, with modern <strong>TypeScript, React / Next.js and Vue / Nuxt</strong> frontends.
       </p>
       <div class="hero-actions">
-        <a class="button button-primary" href="#work">See my work</a>
-        <a class="button button-secondary" href="mailto:{{ site.author.email }}">Get in touch</a>
-        <a class="button button-secondary" href="https://github.com/{{ site.author.github_username }}" target="_blank" rel="noreferrer">GitHub ↗</a>
+        <a class="button button-primary" href="#work">View selected work</a>
+        <a class="text-link" href="mailto:{{ site.author.email }}">Contact me ↗</a>
       </div>
     </div>
 
-    <aside class="hero-card" aria-label="Quick profile">
-      <div class="profile-row">
-        <img class="profile-photo" src="{{ site.baseurl }}/images/profile.jpg" alt="Portrait of Eissa Soubhi">
-        <div>
-          <div class="profile-name">Eissa Soubhi</div>
-          <div class="profile-meta">Paris area, France</div>
-        </div>
+    <aside class="profile-summary" aria-label="Quick profile">
+      <img class="profile-photo" src="{{ site.baseurl }}/images/profile.jpg" alt="Portrait of Eissa Soubhi">
+      <div class="profile-details">
+        <strong>Eissa Soubhi</strong>
+        <span>Paris area, France</span>
       </div>
-      <div class="quick-facts">
-        <div class="fact"><strong>11+</strong><span>years of professional software engineering</span></div>
-        <div class="fact"><strong>Full stack</strong><span>backend, frontend, architecture and delivery</span></div>
-        <div class="fact"><strong>Symfony 8</strong><span>Certified Developer</span></div>
-        <div class="fact"><strong>FR · EN · AR</strong><span>French, English and Arabic</span></div>
+      <dl class="profile-facts">
+        <div><dt>Experience</dt><dd>11+ years</dd></div>
+        <div><dt>Role</dt><dd>Senior / Tech Lead</dd></div>
+        <div><dt>Certification</dt><dd>Symfony 8</dd></div>
+        <div><dt>Languages</dt><dd>FR · EN · AR</dd></div>
+      </dl>
+      <div class="profile-links">
+        <a href="https://github.com/{{ site.author.github_username }}" target="_blank" rel="noreferrer">GitHub ↗</a>
+        <a href="https://www.linkedin.com/in/{{ site.author.linkedin_username }}" target="_blank" rel="noreferrer">LinkedIn ↗</a>
       </div>
     </aside>
   </div>
@@ -57,163 +55,137 @@ description: Senior Full-Stack Engineer and Tech Lead with 11+ years of experien
   <section id="expertise">
     <div class="container">
       <div class="section-heading">
-        <p class="section-kicker">What I bring</p>
-        <div>
-          <h2>Senior engineering across the whole web stack.</h2>
-          <p>I work where product needs meet technical constraints: reliable APIs, fast interfaces, maintainable architecture, good delivery pipelines and pragmatic modernization.</p>
-        </div>
+        <p class="section-kicker">Expertise</p>
+        <h2>Full-stack engineering with a strong backend foundation.</h2>
       </div>
 
       <div class="capabilities">
         <article class="capability">
-          <span class="capability-index">01</span>
           <h3>Backend & architecture</h3>
-          <p>PHP 8, Symfony, Doctrine, APIs, PostgreSQL/MySQL, Redis, RabbitMQ, asynchronous processing, DDD, hexagonal architecture and CQRS where they actually earn their cost.</p>
+          <p>PHP 8, Symfony, Doctrine, REST APIs, PostgreSQL/MySQL, Redis, RabbitMQ, DDD, hexagonal architecture, CQRS and event-driven systems.</p>
         </article>
         <article class="capability">
-          <span class="capability-index">02</span>
           <h3>Frontend & product</h3>
-          <p>TypeScript, React, Next.js, Vue and Nuxt with SSR/SSG, component-driven UI, accessibility, SEO, performance and Core Web Vitals in mind.</p>
+          <p>TypeScript, React, Next.js, Vue, Nuxt, SSR/SSG, reusable UI, accessibility, SEO, performance and Core Web Vitals.</p>
         </article>
         <article class="capability">
-          <span class="capability-index">03</span>
           <h3>Quality & delivery</h3>
-          <p>Automated testing, static analysis, code review, Docker, CI/CD, GitHub Actions, GitLab CI, Jenkins, observability and production troubleshooting.</p>
+          <p>Automated testing, static analysis, code review, Docker, GitHub Actions, GitLab CI, Jenkins, observability and production troubleshooting.</p>
         </article>
       </div>
 
       <div class="stack-row" aria-label="Core technologies">
-        <span class="pill">PHP 8</span><span class="pill">Symfony</span><span class="pill">TypeScript</span><span class="pill">React</span><span class="pill">Next.js</span><span class="pill">Vue 3</span><span class="pill">Nuxt 3</span><span class="pill">PostgreSQL</span><span class="pill">MySQL</span><span class="pill">Redis</span><span class="pill">RabbitMQ</span><span class="pill">Docker</span><span class="pill">GitHub Actions</span><span class="pill">AWS / GCP</span>
+        <span>PHP 8</span><span>Symfony</span><span>TypeScript</span><span>React</span><span>Next.js</span><span>Vue 3</span><span>Nuxt 3</span><span>PostgreSQL</span><span>Redis</span><span>RabbitMQ</span><span>Docker</span><span>AWS / GCP</span>
       </div>
     </div>
   </section>
 
-  <section class="section-soft" id="experience">
+  <section class="section-muted" id="experience">
     <div class="container">
       <div class="section-heading">
         <p class="section-kicker">Experience</p>
-        <div>
-          <h2>Production experience, not tutorial architecture.</h2>
-          <p>I have worked on high-traffic media, automotive, real-estate, e-commerce and business platforms, from feature delivery to technical leadership and modernization.</p>
-        </div>
+        <h2>Selected production environments.</h2>
       </div>
 
       <div class="timeline">
         <article class="role">
-          <div>
-            <div class="role-company">IDGARAGES</div>
-            <div class="role-period">Tech Lead Full-Stack</div>
+          <div class="role-meta">
+            <strong>IDGARAGES</strong>
+            <span>Tech Lead Full-Stack</span>
           </div>
-          <div>
-            <h3>Modern full-stack product delivery</h3>
-            <p>Led and contributed across Symfony services and Nuxt/Vue frontends, event-driven workflows, search, caching, observability and team delivery on a large automotive marketplace.</p>
-            <div class="role-tags"><span>Symfony 6.4</span><span>PHP 8.3</span><span>Nuxt 3</span><span>Vue 3</span><span>RabbitMQ</span><span>Redis</span><span>Elasticsearch</span></div>
-          </div>
-        </article>
-
-        <article class="role">
-          <div>
-            <div class="role-company">France Télévisions</div>
-            <div class="role-period">Senior Full-Stack Engineer</div>
-          </div>
-          <div>
-            <h3>High-traffic media engineering</h3>
-            <p>Worked on france.tv user journeys and editorial/player experiences with Symfony, PHP, TypeScript and Twig, with strong attention to accessibility, frontend quality and performance.</p>
-            <div class="role-tags"><span>Symfony</span><span>PHP 8</span><span>TypeScript</span><span>Twig</span><span>Accessibility</span><span>Performance</span></div>
+          <div class="role-content">
+            <h3>Automotive marketplace</h3>
+            <p>Symfony services and Nuxt/Vue frontends, event-driven workflows, Elasticsearch, Redis, observability and team delivery at scale.</p>
+            <span class="role-stack">Symfony 6.4 · PHP 8.3 · Nuxt 3 · Vue 3 · RabbitMQ · Elasticsearch</span>
           </div>
         </article>
 
         <article class="role">
-          <div>
-            <div class="role-company">Nexity</div>
-            <div class="role-period">Full-Stack Engineer</div>
+          <div class="role-meta">
+            <strong>France Télévisions</strong>
+            <span>Senior Full-Stack Engineer</span>
           </div>
-          <div>
-            <h3>Search, content and modern frontend</h3>
-            <p>Built and modernized real-estate web experiences around Symfony, Vue/Nuxt, Algolia and CMS integrations, including localization, structured data and reusable UI.</p>
-            <div class="role-tags"><span>Symfony</span><span>Vue</span><span>Nuxt</span><span>Algolia</span><span>Sulu CMS</span><span>SEO</span></div>
+          <div class="role-content">
+            <h3>High-traffic media platform</h3>
+            <p>france.tv editorial and player journeys with Symfony, PHP, TypeScript and Twig, with a strong focus on accessibility and frontend performance.</p>
+            <span class="role-stack">Symfony · PHP 8 · TypeScript · Twig · Accessibility · Performance</span>
+          </div>
+        </article>
+
+        <article class="role">
+          <div class="role-meta">
+            <strong>Nexity</strong>
+            <span>Full-Stack Engineer</span>
+          </div>
+          <div class="role-content">
+            <h3>Real-estate digital products</h3>
+            <p>Symfony, Vue/Nuxt, Algolia and CMS integrations for search, localization, structured data and reusable product interfaces.</p>
+            <span class="role-stack">Symfony · Vue · Nuxt · Algolia · Sulu CMS · SEO</span>
           </div>
         </article>
       </div>
 
-      <div class="brand-cloud" aria-label="Other environments">
-        <span class="brand-chip">Caisse des Dépôts</span>
-        <span class="brand-chip">Edenred</span>
-        <span class="brand-chip">Orange Business</span>
-        <span class="brand-chip">E-commerce</span>
-        <span class="brand-chip">Public sector</span>
-        <span class="brand-chip">Media</span>
-      </div>
+      <p class="other-environments">Also worked with Caisse des Dépôts, Edenred, Orange Business and teams across e-commerce, public services and media.</p>
     </div>
   </section>
 
-  <section class="section-dark" id="work">
+  <section id="work">
     <div class="container">
       <div class="section-heading">
-        <p class="section-kicker">Open source</p>
-        <div>
-          <h2>I build tools, not just portfolio screenshots.</h2>
-          <p>My current public work explores developer tooling, AI-assisted engineering, modern SaaS architecture and the editor ecosystem I have contributed to for years.</p>
-        </div>
+        <p class="section-kicker">Selected work</p>
+        <h2>Open-source projects that reflect how I build.</h2>
       </div>
 
       <div class="projects">
         <a class="project-card" href="https://github.com/eissasoubhi/PRTruth" target="_blank" rel="noreferrer">
-          <span class="project-number">01 · FLAGSHIP OSS</span>
+          <span class="project-label">Developer tooling</span>
           <h3>PRTruth ↗</h3>
-          <p>An evidence-based CLI and GitHub Action that checks whether pull-request completion claims are actually supported by repository and CI evidence.</p>
-          <div class="project-tech">TypeScript · GitHub Actions · Developer tooling · AI workflows</div>
+          <p>CLI and GitHub Action for evidence-based pull-request verification against issue acceptance criteria and repository signals.</p>
+          <span class="project-tech">TypeScript · GitHub Actions · CI · AI workflows</span>
         </a>
 
         <a class="project-card" href="https://github.com/eissasoubhi/ai-saas-factory" target="_blank" rel="noreferrer">
-          <span class="project-number">02 · CURRENT BUILD</span>
+          <span class="project-label">Full-stack architecture</span>
           <h3>AI SaaS Factory ↗</h3>
-          <p>A production-oriented B2B SaaS foundation covering multi-tenancy, billing, durable jobs, private files, RAG, metering, audit logs and observability.</p>
-          <div class="project-tech">Next.js · React · TypeScript · PostgreSQL · Stripe · RAG</div>
+          <p>Production-oriented B2B SaaS foundation with multi-tenancy, billing, durable jobs, private files, RAG, metering and observability.</p>
+          <span class="project-tech">Next.js · React · TypeScript · PostgreSQL · Stripe · RAG</span>
         </a>
 
         <a class="project-card" href="https://github.com/eissasoubhi/summernote-bricks" target="_blank" rel="noreferrer">
-          <span class="project-number">03 · OSS HISTORY</span>
+          <span class="project-label">Open-source history</span>
           <h3>Summernote Bricks ↗</h3>
-          <p>A reusable component system for the Summernote WYSIWYG editor, part of a broader set of open-source editor plugins and tooling.</p>
-          <div class="project-tech">JavaScript · WYSIWYG · Plugin architecture · Open source</div>
+          <p>Reusable content components for the Summernote WYSIWYG editor and part of a broader editor-plugin ecosystem.</p>
+          <span class="project-tech">JavaScript · WYSIWYG · Plugin architecture</span>
         </a>
       </div>
 
-      <div class="hero-actions">
-        <a class="button button-secondary" href="https://github.com/{{ site.author.github_username }}?tab=repositories" target="_blank" rel="noreferrer">Explore all repositories ↗</a>
-      </div>
+      <a class="text-link work-link" href="https://github.com/{{ site.author.github_username }}?tab=repositories" target="_blank" rel="noreferrer">View all repositories ↗</a>
     </div>
   </section>
 
-  <section>
+  <section class="section-muted">
     <div class="container approach-grid">
-      <div class="approach-copy">
-        <p class="section-kicker">Engineering approach</p>
-        <h2>Architecture should make delivery easier, not make diagrams prettier.</h2>
-        <p>I like clear boundaries, explicit contracts, strong tests, useful CI and measurable performance. I use AI coding tools extensively, but generated code still needs evidence, review, security and maintainable design.</p>
+      <div>
+        <p class="section-kicker">Approach</p>
+        <h2>Pragmatic engineering, built for teams and production.</h2>
       </div>
       <div class="principles">
-        <div class="principle"><strong>Pragmatic modernization</strong><span>Improve legacy systems incrementally without creating a rewrite-shaped business risk.</span></div>
-        <div class="principle"><strong>Evidence over confidence</strong><span>Tests, observability and CI should make technical claims verifiable.</span></div>
-        <div class="principle"><strong>Complexity has a budget</strong><span>DDD, CQRS and distributed systems are tools, not personality traits.</span></div>
-        <div class="principle"><strong>Product is part of engineering</strong><span>Performance, accessibility, SEO and maintainability matter as much as the happy-path feature.</span></div>
+        <p><strong>Clear architecture.</strong> Boundaries and patterns should reduce friction, not add ceremony.</p>
+        <p><strong>Quality by default.</strong> Tests, CI and observability make changes safer and easier to review.</p>
+        <p><strong>Incremental modernization.</strong> Improve legacy systems without turning every problem into a rewrite.</p>
+        <p><strong>Product awareness.</strong> Performance, accessibility and maintainability are part of engineering quality.</p>
       </div>
     </div>
   </section>
 
-  <section class="section-soft" id="contact">
-    <div class="container">
-      <div class="contact-card">
-        <div>
-          <p class="eyebrow">Let’s work together</p>
-          <h2>Looking for a senior full-stack engineer or tech lead?</h2>
-          <p>Open to discussing Senior Full-Stack / Tech Lead opportunities and freelance missions in France. I can work across backend, frontend and architecture without losing sight of delivery.</p>
-        </div>
-        <div class="contact-links">
-          <a class="button button-primary" href="mailto:{{ site.author.email }}">Email me</a>
-          <a class="button button-secondary" href="https://www.linkedin.com/in/{{ site.author.linkedin_username }}" target="_blank" rel="noreferrer">LinkedIn ↗</a>
-        </div>
+  <section id="contact">
+    <div class="container contact-section">
+      <p class="section-kicker">Contact</p>
+      <h2>Open to Senior Full-Stack and Tech Lead opportunities.</h2>
+      <p>Available to discuss permanent roles and freelance missions in France.</p>
+      <div class="contact-links">
+        <a class="button button-primary" href="mailto:{{ site.author.email }}">Email me</a>
+        <a class="text-link" href="https://www.linkedin.com/in/{{ site.author.linkedin_username }}" target="_blank" rel="noreferrer">LinkedIn ↗</a>
       </div>
     </div>
   </section>
@@ -221,7 +193,7 @@ description: Senior Full-Stack Engineer and Tech Lead with 11+ years of experien
 
 <footer class="site-footer">
   <div class="container footer-inner">
-    <span>© {{ 'now' | date: '%Y' }} Eissa Soubhi · Senior Full-Stack Engineer</span>
-    <span><a href="https://github.com/{{ site.author.github_username }}">GitHub</a> · <a href="https://www.linkedin.com/in/{{ site.author.linkedin_username }}">LinkedIn</a> · <a href="mailto:{{ site.author.email }}">Email</a></span>
+    <span>© {{ 'now' | date: '%Y' }} Eissa Soubhi</span>
+    <span>Senior Full-Stack Engineer · Tech Lead</span>
   </div>
 </footer>


### PR DESCRIPTION
## Goal

Refine the recruiter-facing portfolio into a calmer, more professional and genuinely minimalist presentation.

## What changed

- Replaced the dark gradient-heavy visual language with a white/off-white monochrome system and one restrained blue accent.
- Removed glass effects, large shadows, decorative circles, oversized rounded cards and badge-heavy UI.
- Simplified navigation, buttons, profile facts, expertise blocks, experience rows and contact section.
- Reduced visual noise by using whitespace, thin dividers and flatter typography hierarchy.
- Rewrote several overly promotional headings into more neutral recruiter-facing language.
- Simplified the technology presentation and selected-work cards while preserving the same technical depth.
- Kept the page responsive and accessible, including visible focus states and reduced-motion handling.
- Updated the browser theme color to white to match the new visual system.

## Design direction

Professional, quiet, minimal, senior. The site should feel closer to a polished engineering portfolio or product-company profile than a flashy developer landing page.

## Scope

Only the portfolio layout, homepage structure/copy and dedicated portfolio stylesheet are changed. Existing redirects and legacy routes remain untouched.