### PR TITLE
content: update LinkedIn and Orange experience

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ author:
   email: eissa.soubhi@gmail.com
   twitter_username: eissa_soubhi
   github_username: eissasoubhi
-  linkedin_username: aissa0soubhi
+  linkedin_username: aissa-soubhi
   skype_username: eissa.soubhi
 
 defaults:

--- a/index.html
+++ b/index.html
@@ -93,13 +93,13 @@ description: Senior Full-Stack Engineer and Tech Lead with 11+ years of experien
       <div class="timeline">
         <article class="role">
           <div class="role-meta">
-            <strong>IDGARAGES</strong>
-            <span>Tech Lead Full-Stack</span>
+            <strong>Orange</strong>
+            <span>Full-Stack Engineer</span>
           </div>
           <div class="role-content">
-            <h3>Automotive marketplace</h3>
-            <p>Symfony services and Nuxt/Vue frontends, event-driven workflows, Elasticsearch, Redis, observability and team delivery at scale.</p>
-            <span class="role-stack">Symfony 6.4 · PHP 8.3 · Nuxt 3 · Vue 3 · RabbitMQ · Elasticsearch</span>
+            <h3>E-commerce & business platforms</h3>
+            <p>Worked on e-commerce and business applications across backend and frontend, including Symfony-based services, REST integrations, platform maintenance and modernization.</p>
+            <span class="role-stack">Symfony · PHP · REST APIs · OroCommerce · PrestaShop · React Native</span>
           </div>
         </article>
 
@@ -128,7 +128,7 @@ description: Senior Full-Stack Engineer and Tech Lead with 11+ years of experien
         </article>
       </div>
 
-      <p class="other-environments">Also worked with Caisse des Dépôts, Edenred, Orange Business and teams across e-commerce, public services and media.</p>
+      <p class="other-environments">Also worked with Caisse des Dépôts, Edenred and teams across e-commerce, public services and media.</p>
     </div>
   </section>
 


### PR DESCRIPTION
## Changes
- Update LinkedIn username to `aissa-soubhi` so all generated LinkedIn links point to the correct profile.
- Replace the selected IDGARAGES experience with Orange.
- Present Orange as a Full-Stack Engineer experience across e-commerce/business platforms with Symfony, REST APIs, OroCommerce, PrestaShop and React Native.
- Remove the duplicate Orange mention from the secondary environments line.

No design or unrelated content changes.